### PR TITLE
Propagates errors on download stream

### DIFF
--- a/lib/download-stream.js
+++ b/lib/download-stream.js
@@ -16,6 +16,7 @@ module.exports = class DownloadStream extends Readable {
 
         downloader.on('error', function(err) {
             debug('downloader err: ' + err);
+            self.emit('error', err);
         });
 
         downloader.on('finish', function() {


### PR DESCRIPTION
This change will let the stream listeners to see errors happening in S3.